### PR TITLE
Come up out of the db directory after the migrate commands

### DIFF
--- a/docs/overview/setup-local.md
+++ b/docs/overview/setup-local.md
@@ -46,11 +46,13 @@ wq start myproject . -d myproject.example.com
 cd db/
 ./manage.py migrate
 ./manage.py createsuperuser
+cd ..
 
 # generate htdocs folder via wq build
 ./deploy.sh 0.0.1
 
 # Start local Django server
+cd db/
 ./manage.py runserver
 
 ```


### PR DESCRIPTION
The deploy.sh script is at the top level so to run that you need to come up out of the ./db directory