### PR TITLE
add sqlite install instructions to local dev setup

### DIFF
--- a/docs/overview/setup-local.md
+++ b/docs/overview/setup-local.md
@@ -20,6 +20,10 @@ On Ubuntu (including WSL), you may need to install the python3-venv package:
 sudo apt-get update
 sudo apt-get python3-venv
 ```
+If you don't already have it install SQLite as well
+```bash
+sudo apt-get install sqlite3
+```
 
 If you plan to use wq's Node.js & npm integration, install the relevant package:
 


### PR DESCRIPTION
I found that db writes would fail silently when I didn't have sqlite installed 